### PR TITLE
Improve mobile layout and timer

### DIFF
--- a/images/bear_happy.svg
+++ b/images/bear_happy.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
+  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="35" cy="50" r="5" fill="#000"/>
+  <circle cx="65" cy="50" r="5" fill="#000"/>
+  <path d="M30 60 Q50 85 70 60" stroke="#000" stroke-width="4" fill="#ff6b35" stroke-linecap="round"/>
+  <path d="M34 60 Q50 75 66 60" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/images/bear_normal.svg
+++ b/images/bear_normal.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
+  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="35" cy="50" r="5" fill="#000"/>
+  <circle cx="65" cy="50" r="5" fill="#000"/>
+  <path d="M35 65 Q50 75 65 65" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/images/bear_sad.svg
+++ b/images/bear_sad.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
+  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
+  <circle cx="35" cy="50" r="5" fill="#000"/>
+  <circle cx="65" cy="50" r="5" fill="#000"/>
+  <path d="M35 70 Q50 60 65 70" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <path d="M32 50 Q30 58 32 66 Q34 58 32 50" fill="#00bfff"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ body {
 }
 
 .game-container {
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     position: relative;
     display: flex;
@@ -50,6 +50,13 @@ body {
     text-align: center;
     padding: 2rem;
     max-width: 600px;
+    margin: 0 auto;
+}
+
+@media (max-width: 480px) {
+    .menu-content {
+        padding: 1rem;
+    }
 }
 
 .game-title {
@@ -119,35 +126,27 @@ body {
     height: 120px;
     margin: 0 auto;
     position: relative;
-    image-rendering: pixelated;
     animation: breathe 3s ease-in-out infinite;
 }
 
 .bear-sprite::before {
-    content: '';
+    content: "";
     position: absolute;
     width: 100%;
     height: 100%;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
+    background-image: url(images/bear_normal.svg);
 }
 
-/* デフォルトのクマ（普通の表情） */
-.bear-sprite::before {
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="transparent"/><g transform="translate(4,4)"><rect x="2" y="0" width="4" height="2" fill="%23a0522d"/><rect x="18" y="0" width="4" height="2" fill="%23a0522d"/><rect x="0" y="2" width="2" height="4" fill="%23a0522d"/><rect x="6" y="2" width="12" height="2" fill="%23a0522d"/><rect x="22" y="2" width="2" height="4" fill="%23a0522d"/><rect x="0" y="6" width="2" height="12" fill="%23d2691e"/><rect x="2" y="4" width="2" height="16" fill="%23d2691e"/><rect x="4" y="2" width="2" height="18" fill="%23d2691e"/><rect x="6" y="4" width="12" height="16" fill="%23d2691e"/><rect x="18" y="2" width="2" height="18" fill="%23d2691e"/><rect x="20" y="4" width="2" height="16" fill="%23d2691e"/><rect x="22" y="6" width="2" height="12" fill="%23d2691e"/><rect x="8" y="8" width="2" height="2" fill="%23000"/><rect x="14" y="8" width="2" height="2" fill="%23000"/><rect x="10" y="12" width="4" height="2" fill="%23deb887"/><rect x="11" y="14" width="2" height="2" fill="%23000"/><rect x="10" y="16" width="2" height="1" fill="%23000"/><rect x="12" y="16" width="2" height="1" fill="%23000"/></g></svg>');
-}
-
-/* 悲しいクマ */
 .bear-sprite.sad::before {
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="transparent"/><g transform="translate(4,4)"><rect x="2" y="0" width="4" height="2" fill="%23a0522d"/><rect x="18" y="0" width="4" height="2" fill="%23a0522d"/><rect x="0" y="2" width="2" height="4" fill="%23a0522d"/><rect x="6" y="2" width="12" height="2" fill="%23a0522d"/><rect x="22" y="2" width="2" height="4" fill="%23a0522d"/><rect x="0" y="6" width="2" height="12" fill="%23d2691e"/><rect x="2" y="4" width="2" height="16" fill="%23d2691e"/><rect x="4" y="2" width="2" height="18" fill="%23d2691e"/><rect x="6" y="4" width="12" height="16" fill="%23d2691e"/><rect x="18" y="2" width="2" height="18" fill="%23d2691e"/><rect x="20" y="4" width="2" height="16" fill="%23d2691e"/><rect x="22" y="6" width="2" height="12" fill="%23d2691e"/><rect x="8" y="8" width="2" height="2" fill="%23000"/><rect x="14" y="8" width="2" height="2" fill="%23000"/><rect x="9" y="10" width="1" height="3" fill="%2300bfff"/><rect x="15" y="10" width="1" height="3" fill="%2300bfff"/><rect x="10" y="12" width="4" height="2" fill="%23deb887"/><rect x="11" y="16" width="2" height="2" fill="%23000"/><rect x="10" y="18" width="1" height="1" fill="%23000"/><rect x="13" y="18" width="1" height="1" fill="%23000"/></g></svg>');
+    background-image: url(images/bear_sad.svg);
 }
 
-/* 嬉しいクマ */
 .bear-sprite.happy::before {
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" fill="transparent"/><g transform="translate(4,4)"><rect x="2" y="0" width="4" height="2" fill="%23a0522d"/><rect x="18" y="0" width="4" height="2" fill="%23a0522d"/><rect x="0" y="2" width="2" height="4" fill="%23a0522d"/><rect x="6" y="2" width="12" height="2" fill="%23a0522d"/><rect x="22" y="2" width="2" height="4" fill="%23a0522d"/><rect x="0" y="6" width="2" height="12" fill="%23d2691e"/><rect x="2" y="4" width="2" height="16" fill="%23d2691e"/><rect x="4" y="2" width="2" height="18" fill="%23d2691e"/><rect x="6" y="4" width="12" height="16" fill="%23d2691e"/><rect x="18" y="2" width="2" height="18" fill="%23d2691e"/><rect x="20" y="4" width="2" height="16" fill="%23d2691e"/><rect x="22" y="6" width="2" height="12" fill="%23d2691e"/><rect x="7" y="8" width="3" height="2" fill="%23000"/><rect x="14" y="8" width="3" height="2" fill="%23000"/><rect x="9" y="12" width="1" height="1" fill="%23ff69b4"/><rect x="14" y="12" width="1" height="1" fill="%23ff69b4"/><rect x="10" y="12" width="4" height="2" fill="%23deb887"/><rect x="9" y="15" width="1" height="1" fill="%23000"/><rect x="11" y="16" width="2" height="1" fill="%23000"/><rect x="14" y="15" width="1" height="1" fill="%23000"/><rect x="10" y="17" width="4" height="1" fill="%23ff0000"/></g></svg>');
+    background-image: url(images/bear_happy.svg);
 }
-
 @keyframes breathe {
     0%, 100% { transform: scale(1); }
     50% { transform: scale(1.05); }
@@ -293,7 +292,8 @@ body {
 
 .timer-container {
     flex-grow: 1;
-    max-width: 400px;
+    width: 100%;
+    max-width: 600px;
 }
 
 .timer-bar {
@@ -310,7 +310,7 @@ body {
     height: 100%;
     background: linear-gradient(90deg, #00ff00, #ffff00, #ff6b35, #ff0000);
     border-radius: 13px;
-    transition: width 0.1s linear;
+    transition: width 1s linear;
     width: 100%;
 }
 
@@ -403,11 +403,12 @@ body {
 
 .answers-container {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
 }
 
 .answer-btn {
+    width: 100%;
     padding: 1.5rem;
     font-size: clamp(1rem, 2.5vw, 1.2rem);
     font-family: inherit;
@@ -591,9 +592,9 @@ body {
         order: 2;
         min-width: auto;
     }
-    
+
     .answers-container {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, 1fr);
     }
     
     .hints-section {


### PR DESCRIPTION
## Summary
- Center title screen on mobile with responsive menu spacing
- Replace bear sprite with expressive SVG illustrations
- Render quiz options in 2x2 grid and lengthen smooth timer bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b66e35fe8833082f100abca741585