### PR TITLE
Improve bear graphics and fuse animation

### DIFF
--- a/images/bear_happy.svg
+++ b/images/bear_happy.svg
@@ -1,9 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
-  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="35" cy="50" r="5" fill="#000"/>
-  <circle cx="65" cy="50" r="5" fill="#000"/>
-  <path d="M30 60 Q50 85 70 60" stroke="#000" stroke-width="4" fill="#ff6b35" stroke-linecap="round"/>
-  <path d="M34 60 Q50 75 66 60" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <circle cx="50" cy="55" r="35" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="70" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="9" fill="#ffe0e0"/>
+  <circle cx="70" cy="35" r="9" fill="#ffe0e0"/>
+  <ellipse cx="50" cy="65" rx="20" ry="16" fill="#fff"/>
+  <circle cx="38" cy="55" r="5" fill="#000"/>
+  <circle cx="62" cy="55" r="5" fill="#000"/>
+  <circle cx="38" cy="55" r="2" fill="#fff"/>
+  <circle cx="62" cy="55" r="2" fill="#fff"/>
+  <circle cx="50" cy="60" r="6" fill="#61380b"/>
+  <path d="M40 64 Q50 84 60 64" stroke="#61380b" stroke-width="3" fill="#ff6b35" stroke-linecap="round"/>
+  <path d="M42 64 Q50 74 58 64" stroke="#61380b" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/images/bear_normal.svg
+++ b/images/bear_normal.svg
@@ -1,8 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
-  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="35" cy="50" r="5" fill="#000"/>
-  <circle cx="65" cy="50" r="5" fill="#000"/>
-  <path d="M35 65 Q50 75 65 65" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <circle cx="50" cy="55" r="35" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="70" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="9" fill="#ffe0e0"/>
+  <circle cx="70" cy="35" r="9" fill="#ffe0e0"/>
+  <ellipse cx="50" cy="65" rx="20" ry="16" fill="#fff"/>
+  <circle cx="38" cy="55" r="5" fill="#000"/>
+  <circle cx="62" cy="55" r="5" fill="#000"/>
+  <circle cx="38" cy="55" r="2" fill="#fff"/>
+  <circle cx="62" cy="55" r="2" fill="#fff"/>
+  <circle cx="50" cy="60" r="6" fill="#61380b"/>
+  <path d="M40 70 Q50 76 60 70" stroke="#61380b" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/images/bear_sad.svg
+++ b/images/bear_sad.svg
@@ -1,9 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="55" r="35" fill="#d28b26"/>
-  <circle cx="30" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="70" cy="35" r="15" fill="#a0522d"/>
-  <circle cx="35" cy="50" r="5" fill="#000"/>
-  <circle cx="65" cy="50" r="5" fill="#000"/>
-  <path d="M35 70 Q50 60 65 70" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
-  <path d="M32 50 Q30 58 32 66 Q34 58 32 50" fill="#00bfff"/>
+  <circle cx="50" cy="55" r="35" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="70" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="9" fill="#ffe0e0"/>
+  <circle cx="70" cy="35" r="9" fill="#ffe0e0"/>
+  <ellipse cx="50" cy="65" rx="20" ry="16" fill="#fff"/>
+  <circle cx="38" cy="55" r="5" fill="#000"/>
+  <circle cx="62" cy="55" r="5" fill="#000"/>
+  <circle cx="38" cy="55" r="2" fill="#fff"/>
+  <circle cx="62" cy="55" r="2" fill="#fff"/>
+  <circle cx="50" cy="60" r="6" fill="#61380b"/>
+  <path d="M40 72 Q50 62 60 72" stroke="#61380b" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M34 55 Q32 63 34 71 Q36 63 34 55" fill="#00bfff"/>
 </svg>

--- a/style.css
+++ b/style.css
@@ -266,12 +266,25 @@ body {
 
 .fuse {
     position: absolute;
-    top: -10px;
-    right: -5px;
-    width: 3px;
-    height: 20px;
-    background: linear-gradient(to bottom, #ffa500, #ff6b35);
-    animation: burn 1s ease-in-out infinite;
+    top: -15px;
+    right: -25px;
+    width: 30px;
+    height: 3px;
+    background: #a0522d;
+    border-radius: 2px;
+    transform: rotate(45deg);
+}
+
+.fuse::after {
+    content: "";
+    position: absolute;
+    top: -3px;
+    left: 0;
+    width: 8px;
+    height: 8px;
+    background: radial-gradient(circle, #ff0 0%, #ffa500 60%, transparent 60%);
+    border-radius: 50%;
+    animation: spark 0.6s linear infinite;
 }
 
 @keyframes shake {
@@ -284,11 +297,11 @@ body {
     0%, 100% { transform: scale(1); }
     50% { transform: scale(1.1); }
 }
-
-@keyframes burn {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
+@keyframes spark {
+    0% { transform: translateX(0); opacity: 1; }
+    100% { transform: translateX(22px); opacity: 0; }
 }
+
 
 .timer-container {
     flex-grow: 1;


### PR DESCRIPTION
## Summary
- Redraw bear sprites with softer colors and friendlier features.
- Replace static bomb fuse with angled spark animation.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b6c0e67048330bbff8673252d0b13