### PR TITLE
Add anxious bear expressions tied to countdown

### DIFF
--- a/images/bear_panic.svg
+++ b/images/bear_panic.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="55" r="35" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="70" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="9" fill="#ffe0e0"/>
+  <circle cx="70" cy="35" r="9" fill="#ffe0e0"/>
+  <ellipse cx="50" cy="65" rx="20" ry="16" fill="#fff"/>
+  <circle cx="38" cy="55" r="5" fill="#000"/>
+  <circle cx="62" cy="55" r="5" fill="#000"/>
+  <circle cx="38" cy="55" r="2" fill="#fff"/>
+  <circle cx="62" cy="55" r="2" fill="#fff"/>
+  <circle cx="50" cy="60" r="6" fill="#61380b"/>
+  <ellipse cx="50" cy="72" rx="10" ry="8" fill="#61380b"/>
+  <path d="M32 50 Q30 58 32 66 Q34 58 32 50" fill="#00bfff"/>
+  <path d="M68 45 Q66 53 68 61 Q70 53 68 45" fill="#00bfff"/>
+</svg>

--- a/images/bear_worried.svg
+++ b/images/bear_worried.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="55" r="35" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="70" cy="35" r="15" fill="#f2c99f"/>
+  <circle cx="30" cy="35" r="9" fill="#ffe0e0"/>
+  <circle cx="70" cy="35" r="9" fill="#ffe0e0"/>
+  <ellipse cx="50" cy="65" rx="20" ry="16" fill="#fff"/>
+  <circle cx="38" cy="55" r="5" fill="#000"/>
+  <circle cx="62" cy="55" r="5" fill="#000"/>
+  <circle cx="38" cy="55" r="2" fill="#fff"/>
+  <circle cx="62" cy="55" r="2" fill="#fff"/>
+  <circle cx="50" cy="60" r="6" fill="#61380b"/>
+  <ellipse cx="50" cy="70" rx="6" ry="4" fill="#61380b"/>
+  <path d="M68 45 Q66 53 68 61 Q70 53 68 45" fill="#00bfff"/>
+</svg>

--- a/script.js
+++ b/script.js
@@ -415,6 +415,7 @@ function stopTimer() {
 function updateTimerDisplay() {
     const timerText = document.getElementById('timer-text');
     const timerFill = document.getElementById('timer-fill');
+    const gameBear = document.getElementById('game-bear');
     
     if (timerText) {
         timerText.textContent = gameState.timer;
@@ -430,6 +431,17 @@ function updateTimerDisplay() {
     if (timerFill) {
         const percentage = (gameState.timer / gameState.maxTimer) * 100;
         timerFill.style.width = Math.max(0, percentage) + '%';
+    }
+
+    // 残り時間に応じてクマの表情を変化
+    if (gameBear && !gameBear.classList.contains('happy') && !gameBear.classList.contains('sad')) {
+        if (gameState.timer <= 5) {
+            gameBear.className = 'bear-sprite panic';
+        } else if (gameState.timer <= 10) {
+            gameBear.className = 'bear-sprite worried';
+        } else {
+            gameBear.className = 'bear-sprite';
+        }
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -147,6 +147,16 @@ body {
 .bear-sprite.happy::before {
     background-image: url(images/bear_happy.svg);
 }
+.bear-sprite.worried::before {
+    background-image: url(images/bear_worried.svg);
+}
+.bear-sprite.panic::before {
+    background-image: url(images/bear_panic.svg);
+}
+/* 強い焦りのときはブルブル震える */
+.bear-sprite.panic {
+    animation: breathe 3s ease-in-out infinite, shake 0.3s ease-in-out infinite;
+}
 @keyframes breathe {
     0%, 100% { transform: scale(1); }
     50% { transform: scale(1.05); }


### PR DESCRIPTION
## Summary
- Add worried and panic bear SVGs and styling, including a shake animation for intense panic
- Update timer logic to switch bear expressions as time runs out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c862eaa9c833087f2a4ab160baca5